### PR TITLE
added line-height property in span to fix overlapping.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -193,6 +193,7 @@ nav .current {
     padding: 0.5em;
     background: #FFF;
     border-radius: 6px;
+    line-height: 50px;
 }
 
 .featured-resource {


### PR DESCRIPTION
Added line-height property to increase the height of the line so to add spacing between <strong>"Featured"</strong> and <strong>"Resources"</strong>.

- fix issue - #69

![Screenshot (207)](https://user-images.githubusercontent.com/30374226/80374243-048c0f00-88b4-11ea-92ea-22458a787b3c.png)

